### PR TITLE
Fix README typo: change 'taskes' to 'tasks'

### DIFF
--- a/my-app/README.md
+++ b/my-app/README.md
@@ -34,4 +34,4 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-this is the change that i needed to do to accomplish all of the taskes
+this is the change that i needed to do to accomplish all of the tasks


### PR DESCRIPTION
This PR fixes a simple spelling error in the README.md file.

## Changes made:
- Fixed typo: changed 'taskes' to 'tasks' in line 37 of README.md
- Original: 'taskes' (incorrect spelling)
- Fixed: 'tasks' (correct spelling)

This ensures proper spelling in the project documentation.

The typo was likely a simple typing error that needed correction.

Fixes #2